### PR TITLE
Build with Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
This can be merged once `confluent_kafka` builds on 3.12.